### PR TITLE
minor lattice update to avoid deprecated msg & relocated CPU% to avoid overlap

### DIFF
--- a/pitter-patter.lua
+++ b/pitter-patter.lua
@@ -170,7 +170,7 @@ function redraw()
     end
   end
   screen.level(util.round(util.linlin(0,100,0,15,last_cpu)))
-  screen.move(0,5+9)
+  screen.move(110,5+9)
   screen.text(string.format("%2.0f",last_cpu) .. "%")
   screen.level(10)
   screen.move(0, 5)

--- a/pitter-patter.lua
+++ b/pitter-patter.lua
@@ -56,7 +56,7 @@ function init()
 
   for _, division in ipairs(divisions) do
     local beat = 1
-    sequencer:new_pattern({
+    sequencer:new_sprocket({
       action=function(t)
         if params:get("main_play") == 1 then
           for i = 1, 4 do sequencers[i]:update(division, beat) end


### PR DESCRIPTION
Hi @schollz ,
Here's a small PR to address the following:

- When loading the script: there was a `'new_pattern' is deprecated; use 'new_sprocket' instead.` message
- The "muted" message and the CPU% were overlapping so it has been relocated to the opposite side of the grid UI

Thank you again for this lovely script and for considering this lil' contribution! 